### PR TITLE
Improve handling of categorical variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,13 +14,13 @@ Underscores = "d9a01c3f-67ce-4d8c-9b55-35f6e4050bb1"
 
 [compat]
 AbstractPlotting = "0.15, 0.16"
-DataAPI = "1.4"
+DataAPI = "1.6"
 DataFrames = "0.22"
 NamedTupleTools = "0.13"
 StructArrays = "0.4, 0.5"
 UnPack = "1.0"
 Underscores = "2.0"
-julia = "1"
+julia = "1.5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/TabularMakie.jl
+++ b/src/TabularMakie.jl
@@ -7,13 +7,12 @@ using AbstractPlotting: MakieLayout
 using AbstractPlotting.MakieLayout: Optional, LegendEntry, EntryGroup
 # import some internal functions of AbstractPlotting
 # TODO: test behavior of these functions
-using AbstractPlotting: categorical_labels, categorical_range
+using AbstractPlotting: categorical_labels, categorical_range, categorical_positions, categorical_trait, Continuous, Automatic
 
 using DataFrames
 using Underscores: @_
 using StructArrays
 using UnPack: @unpack
-using DataAPI: refarray
 #using Statistics
 using NamedTupleTools: delete
 

--- a/src/TabularMakie.jl
+++ b/src/TabularMakie.jl
@@ -7,7 +7,11 @@ using AbstractPlotting: MakieLayout
 using AbstractPlotting.MakieLayout: Optional, LegendEntry, EntryGroup
 # import some internal functions of AbstractPlotting
 # TODO: test behavior of these functions
-using AbstractPlotting: categorical_labels, categorical_range, categorical_positions, categorical_trait, Continuous, Automatic
+
+using AbstractPlotting: Automatic
+include("categorical.jl")
+using .TmpCategorical: categorical_labels, categorical_range, categorical_positions, categorical_trait, Categorical, HasRefPool, Continuous, Automatic
+# using AbstractPlotting: categorical_labels, categorical_range, categorical_positions, categorical_trait, Continuous, Automatic
 
 using DataFrames
 using Underscores: @_
@@ -15,6 +19,7 @@ using StructArrays
 using UnPack: @unpack
 #using Statistics
 using NamedTupleTools: delete
+
 
 include("mini-language.jl")
 include("attribute-dicts.jl")

--- a/src/TabularMakie.jl
+++ b/src/TabularMakie.jl
@@ -10,7 +10,7 @@ using AbstractPlotting.MakieLayout: Optional, LegendEntry, EntryGroup
 
 using AbstractPlotting: Automatic
 include("categorical.jl")
-using .TmpCategorical: categorical_labels, categorical_range, categorical_positions, categorical_trait, Categorical, HasRefPool, Continuous, Automatic
+using .TmpCategorical: categorical_labels, categorical_range, categorical_positions, categorical_trait, Categorical, HasRefPool, Continuous
 # using AbstractPlotting: categorical_labels, categorical_range, categorical_positions, categorical_trait, Continuous, Automatic
 
 using DataFrames
@@ -19,7 +19,6 @@ using StructArrays
 using UnPack: @unpack
 #using Statistics
 using NamedTupleTools: delete
-
 
 include("mini-language.jl")
 include("attribute-dicts.jl")

--- a/src/TabularMakie.jl
+++ b/src/TabularMakie.jl
@@ -5,12 +5,15 @@ export tplot, lplot
 using AbstractPlotting
 using AbstractPlotting: MakieLayout
 using AbstractPlotting.MakieLayout: Optional, LegendEntry, EntryGroup
+# import some internal functions of AbstractPlotting
+# TODO: test behavior of these functions
+using AbstractPlotting: categorical_labels, categorical_range
 
 using DataFrames
 using Underscores: @_
 using StructArrays
 using UnPack: @unpack
-using DataAPI: refpool, refarray
+using DataAPI: refarray
 #using Statistics
 using NamedTupleTools: delete
 

--- a/src/attribute-dicts.jl
+++ b/src/attribute-dicts.jl
@@ -86,7 +86,7 @@ function unique_or_identity(x)
 	end
 end
 
-is_discrete(x) = !(categorical_trait(x) isa AbstractPlotting.Continuous)
+is_discrete(x) = !(categorical_trait(x) isa Continuous)
 
 "This function replaces group indicators (numbers, categories) by attributes that can be plotted (:solid, :red, etc...)"
 function lookup_symbols(df, group_pairs, style_pairs, group_dict)

--- a/src/attribute-dicts.jl
+++ b/src/attribute-dicts.jl
@@ -28,10 +28,10 @@ function build_group_dict(df, group_pairs)
 	group_dict = Dict()
 	for (attr, var) in pairs(group_pairs)
 		if attr ∉ [:stack, :dodge, :group]
-			var_levels = levels(get(df, var))
+			var_levels = categorical_labels(get(df, var))
 			thm = AbstractPlotting.current_default_theme().palette
 		
-			group_dict[attr] = [var_levels[i] => thm[attr][][i] for i in 1:length(var_levels)]
+			group_dict[attr] = [var_levels[i] => thm[attr][][i] for i in categorical_range(get(df, var))]
 		end
 	end
 
@@ -75,7 +75,7 @@ function group_style_other(df, dict)
 	(; group_pairs, style_pairs, kws)
 end
 
-get_marker(x, marker_dict) = last.(marker_dict)[refarray(x)]
+get_marker(x, marker_dict) = last.(marker_dict)[categorical_positions(x)]
 
 function unique_or_identity(x)
 	x_unique = unique(x)
@@ -86,7 +86,7 @@ function unique_or_identity(x)
 	end
 end
 
-is_discrete(x) = !(eltype(x) <: Number)
+is_discrete(x) = !(categorical_trait(x) isa AbstractPlotting.Continuous)
 
 "This function replaces group indicators (numbers, categories) by attributes that can be plotted (:solid, :red, etc...)"
 function lookup_symbols(df, group_pairs, style_pairs, group_dict)

--- a/src/categorical.jl
+++ b/src/categorical.jl
@@ -3,6 +3,7 @@ module TmpCategorical
 export Continuous, HasRefPool, Categorical,
     catetorical_labels, categorical_range, categorical_trait, categorical_positions
 
+using DataAPI: DataAPI
 using AbstractPlotting: AbstractPlotting, categorical_trait, Categorical, Automatic
 
 const AP = AbstractPlotting
@@ -11,6 +12,7 @@ struct HasRefPool end
 const Continuous = AP.Continous
 
 AP.categorical_trait(x::AbstractVector) = !isnothing(DataAPI.refpool(x)) ? HasRefPool() : Categorical()
+AP.categorical_trait(x::AbstractVector{<: Number}) = Continuous()
 
 AP.categoric_labels(::HasRefPool,  xs) = DataAPI.levels(xs)
 
@@ -24,7 +26,7 @@ categorical_range(xs) = categorical_range(categorical_trait(xs), xs)
 
 function categorical_range(t, xs)
     labels  = categorical_labels(t, xs)
-    AP.categoric_range(t, labels)
+    AP.categoric_range(labels)
 end
 
 #categorical_range(::HasRefPool,  xs) = keys(DataAPI.refpool(xs))

--- a/src/categorical.jl
+++ b/src/categorical.jl
@@ -1,0 +1,49 @@
+module TmpCategorical
+
+export Continuous, HasRefPool, Categorical,
+    catetorical_labels, categorical_range, categorical_trait, categorical_positions
+
+using AbstractPlotting: AbstractPlotting, categorical_trait, Categorical, Automatic
+
+const AP = AbstractPlotting
+
+struct HasRefPool end
+const Continuous = AP.Continous
+
+AP.categorical_trait(x::AbstractVector) = !isnothing(DataAPI.refpool(x)) ? HasRefPool() : Categorical()
+
+AP.categoric_labels(::HasRefPool,  xs) = DataAPI.levels(xs)
+
+categorical_labels = AP.categoric_labels
+
+# -----------------------------
+# ----- Categorical range -----
+# -----------------------------
+
+categorical_range(xs) = categorical_range(categorical_trait(xs), xs)
+
+function categorical_range(t, xs)
+    labels  = categorical_labels(t, xs)
+    AP.categoric_range(t, labels)
+end
+
+#categorical_range(::HasRefPool,  xs) = keys(DataAPI.refpool(xs))
+
+# -----------------------------
+# --- Categorical positions ---
+# -----------------------------
+
+categorical_positions(xs) = categorical_positions(categorical_trait(xs), xs)
+categorical_positions(::Continuous, xs) = xs
+function categorical_positions(t::AP.Categorical, xs)
+    labels = categorical_labels(xs)
+    categorical_position.(Ref(t), xs, Ref(xs), Ref(labels))
+end
+categorical_positions(::HasRefPool, xs) = DataAPI.refarray(xs)
+
+categorical_position(x, xs) = categorical_position(categorical_trait(xs), x, xs)
+categorical_position(::Categorical, x, xs, labels = categorical_labels(xs)) = findfirst(l -> l == x, labels)
+categorical_position(::Continuous,  x, _)  = x
+categorical_position(::HasRefPool,  x, xs) = DataAPI.invrefpool(xs)[x]
+
+end

--- a/src/layout.jl
+++ b/src/layout.jl
@@ -32,19 +32,19 @@ function draw_axis!(P, figpos, df, args, layout_vars, group_dict, style_dict, kw
 		# Compute group key and index for layouting variables
 		if !isnothing(grp_y)
 			ykey = get(groupdf, grp_y) |> unique |> only
-			i = get(groupdf, grp_y) |> refarray |> unique |> only |> Int
+			i = categorical_positions(get(groupdf, grp_y)) |> unique |> only |> Int
 		else
 			i = 1
 		end
 		if !isnothing(grp_x)
 			xkey = get(groupdf, grp_x) |> unique |> only
-			j = get(groupdf, grp_x) |> refarray |> unique |> only |> Int
+			j = categorical_positions(get(groupdf, grp_x)) |> unique |> only |> Int
 		else
 			j = 1
 		end
 		if !isnothing(grp_wrap)
 			wrapkey = get(groupdf, grp_wrap) |> unique |> only
-			ind = get(groupdf, grp_wrap) |> refarray |> unique |> only |> Int
+			ind = categorical_positions(get(groupdf, grp_wrap)) |> unique |> only |> Int
 
 			i, j = fldmod1(ind, J) 
 		end

--- a/src/plot.jl
+++ b/src/plot.jl
@@ -12,7 +12,7 @@ function _grouped_plot(::AllAtOnce, P, ax, df, group_dict, args, kws, group_pair
 	
 	pairs = lookup_symbols(df, group_pairs, style_pairs, group_dict)
 
-	plt = plot!(P, ax, xyz...; kws..., pairs...)
+	plt = plot!(P, ax, categorical_positions.(xyz)...; kws..., pairs...)
 	
 	categorical_ticks!(ax, xyz[1], xyz[2])
 
@@ -37,7 +37,7 @@ function _grouped_plot(::Incremental, P, ax, gdf, group_dict, args, kws, group_p
 		
 		pairs = lookup_symbols(df, group_pairs, style_pairs, group_dict)
 		
-		plt = plot!(P, ax, xyz...; kws..., pairs...)
+		plt = plot!(P, ax, categorical_positions.(xyz)...; kws..., pairs...)
 
 		categorical_ticks!(ax, xyz[1], xyz[2])
 		

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -12,12 +12,12 @@ function categorical_ticks!(ax, x, y)
 end
 
 function categorical_ticks(var)
-	rp0 = refpool(var)
-	if isnothing(rp0)
+	ticks  = AbstractPlotting.categorical_range(var) 
+	labels = AbstractPlotting.categorical_labels(var)
+
+	if ticks isa Automatic
 		nothing
-	else
-		rp = pairs(rp0)
-		ticks = keys(rp), values(rp)
+	else 
+		ticks, labels
 	end
-		
 end

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -12,8 +12,8 @@ function categorical_ticks!(ax, x, y)
 end
 
 function categorical_ticks(var)
-	ticks  = AbstractPlotting.categorical_range(var) 
-	labels = AbstractPlotting.categorical_labels(var)
+	ticks  = categorical_range(var)  # internal function from AbstractPlotting
+	labels = categorical_labels(var) # internal function from AbstractPlotting
 
 	if ticks isa Automatic
 		nothing

--- a/src/ticks.jl
+++ b/src/ticks.jl
@@ -12,8 +12,8 @@ function categorical_ticks!(ax, x, y)
 end
 
 function categorical_ticks(var)
-	ticks  = categorical_range(var)  # internal function from AbstractPlotting
-	labels = categorical_labels(var) # internal function from AbstractPlotting
+	ticks  = categorical_range(var)
+	labels = categorical_labels(var)
 
 	if ticks isa Automatic
 		nothing


### PR DESCRIPTION
<s> has to wait for JuliaPlots/AbstractPlotting.jl#667 </s>

Temporarily implements `categorical_range`, `categorical_labels` and `categorical_positions` from JuliaPlots/AbstractPlotting.jl#667 and uses it for legends and categorical ticks.

cc @SimonDanisch: It would be very easy to make this completely independent from AbstractPlotting's categorical conversions.